### PR TITLE
Create `release` workflow to publish the package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+name: release
+
+permissions:
+  contents: read
+  id-token: write
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    environment: production
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: npm ci
+        run: npm ci
+
+      - name: npm publish
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}


### PR DESCRIPTION
We will publish the `@slidoapp/qrcode` package to <https://npmjs.com> registry.

Publishing is triggered by creating a tag and the release page for it in the GitHub repository.

Published package will have provenance record to ensure it was built from our source code.

https://github.blog/security/supply-chain-security/introducing-npm-package-provenance/
https://docs.npmjs.com/generating-provenance-statements