### PR TITLE
Implement `canvas.renderToBlob()` function to export QR Code as blob data

### DIFF
--- a/lib/renderer/canvas.js
+++ b/lib/renderer/canvas.js
@@ -61,3 +61,21 @@ exports.renderToDataURL = function renderToDataURL (qrData, canvas, options) {
 
   return canvasEl.toDataURL(type, rendererOpts.quality)
 }
+
+exports.renderToBlob = function renderToBlob (cb, qrData, canvas, options) {
+  let opts = options
+
+  if (typeof opts === 'undefined' && (!canvas || !canvas.getContext)) {
+    opts = canvas
+    canvas = undefined
+  }
+
+  if (!opts) opts = {}
+
+  const canvasEl = exports.render(qrData, canvas, opts)
+
+  const type = opts.type || 'image/png'
+  const rendererOpts = opts.rendererOpts || {}
+
+  canvasEl.toBlob(cb, type, rendererOpts.quality)
+}


### PR DESCRIPTION
This exposes the `HTMLCanvasElement.toBlob()` method as `canvas.renderToBlob()`.

https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toBlob

Implements #13 